### PR TITLE
fix(jwks): prevent concurrent map access in certs cache

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: MIT
 
-## Golden config for golangci-lint v2.1.2
+## Golden config for golangci-lint v2.7.1
 #
 # This is the best config for golangci-lint based on my experience and opinion.
 # It is very strict, but not extremely strict.

--- a/Dockerfile.multi-stage
+++ b/Dockerfile.multi-stage
@@ -2,7 +2,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-ARG GO_VERSION=1.26.4
+ARG GO_VERSION=1.26.5
 FROM golang:${GO_VERSION}-alpine AS builder
 
 WORKDIR /build

--- a/Makefile
+++ b/Makefile
@@ -109,12 +109,12 @@ $(LOCALBIN):
 GOLANGCI_LINT = $(LOCALBIN)/golangci-lint
 
 ## Tool Versions
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v2.7.1
 
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
+	$(call go-install-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/v2/cmd/golangci-lint,$(GOLANGCI_LINT_VERSION))
 
 # go-install-tool will 'go install' any package with custom target and name of binary, if it doesn't exist
 # $1 - target path with name of binary

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ vet: ## Run go vet against code.
 
 .PHONY: test-unit
 test-unit: ## Run tests.
-	go test ./... -cover -coverprofile=cover.profile
+	go test ./... -race -cover -coverprofile=cover.profile
 
 
 .PHONY: lint

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module issuer-service-go
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/caarlos0/env/v11 v11.4.1

--- a/internal/jwks/file_provider.go
+++ b/internal/jwks/file_provider.go
@@ -80,9 +80,15 @@ func (fp *FileProvider) GetDefaultRealm(realm string) *DefaultRealm {
 	fp.cacheMutex.Lock()
 	defer fp.cacheMutex.Unlock()
 
+	activeJwk, exists := fp.certsCacheMap[config.Active]
+	if !exists {
+		log.Warn().Msg("no active JWK available in cache for default realm")
+		return nil
+	}
+
 	defaultRealm := &DefaultRealm{
 		Realm:     realm,
-		PublicKey: fp.certsCacheMap[config.Active].PublicKey,
+		PublicKey: activeJwk.PublicKey,
 	}
 
 	return defaultRealm
@@ -221,6 +227,8 @@ func startScheduler(fp *FileProvider) {
 
 func executeTask(fp *FileProvider) {
 	log.Debug().Msg("updating the certificates from mounted files...")
+	fp.cacheMutex.Lock()
+	defer fp.cacheMutex.Unlock()
 	err := updateCerts(fp)
 	if err != nil {
 		log.Error().Msgf("failed to update certificate: %v", err)

--- a/internal/jwks/file_provider.go
+++ b/internal/jwks/file_provider.go
@@ -100,8 +100,6 @@ func (fp *FileProvider) IsSchedulerRunning() bool {
 
 func initialize(fp *FileProvider) error {
 	log.Info().Msgf("initializing JWKS cache...")
-	fp.cacheMutex.Lock()
-	defer fp.cacheMutex.Unlock()
 
 	if err := updateCerts(fp); err != nil {
 		return fmt.Errorf("failed to update certificates: %w", err)
@@ -126,18 +124,22 @@ func updateCerts(fp *FileProvider) error {
 		return err
 	}
 
-	fp.certsCacheMap = make(map[config.Type]*Jwk)
+	certsCacheMap := make(map[config.Type]*Jwk)
 
-	addJwkToCache(fp, config.Active, jwkActive)
-	addJwkToCache(fp, config.Previous, jwkPrev)
-	addJwkToCache(fp, config.Next, jwkNext)
+	addJwkToCache(certsCacheMap, config.Active, jwkActive)
+	addJwkToCache(certsCacheMap, config.Previous, jwkPrev)
+	addJwkToCache(certsCacheMap, config.Next, jwkNext)
+
+	fp.cacheMutex.Lock()
+	fp.certsCacheMap = certsCacheMap
+	fp.cacheMutex.Unlock()
 
 	return nil
 }
 
-func addJwkToCache(fp *FileProvider, certType config.Type, jwk *Jwk) {
+func addJwkToCache(certsCacheMap map[config.Type]*Jwk, certType config.Type, jwk *Jwk) {
 	var found bool
-	for _, value := range fp.certsCacheMap {
+	for _, value := range certsCacheMap {
 		if value.Kid == jwk.Kid {
 			found = true
 			break
@@ -145,7 +147,7 @@ func addJwkToCache(fp *FileProvider, certType config.Type, jwk *Jwk) {
 	}
 
 	if !found {
-		fp.certsCacheMap[certType] = jwk
+		certsCacheMap[certType] = jwk
 	} else {
 		log.Debug().Msgf("JWK with kid %s already exists in cache", jwk.Kid)
 	}
@@ -227,8 +229,6 @@ func startScheduler(fp *FileProvider) {
 
 func executeTask(fp *FileProvider) {
 	log.Debug().Msg("updating the certificates from mounted files...")
-	fp.cacheMutex.Lock()
-	defer fp.cacheMutex.Unlock()
 	err := updateCerts(fp)
 	if err != nil {
 		log.Error().Msgf("failed to update certificate: %v", err)

--- a/internal/server/handler.go
+++ b/internal/server/handler.go
@@ -96,6 +96,13 @@ func (h *Handler) IssuerHandler(c *fiber.Ctx) error {
 	log.Debug().Msgf("Request received on issuer endpoint for realm %s", realm)
 
 	defaultRealm := h.jwksProvider.GetDefaultRealm(realm)
+	if defaultRealm == nil {
+		log.Error().Msgf("no active key available for realm %s", realm)
+		return c.Status(fiber.StatusServiceUnavailable).JSON(fiber.Error{
+			Code:    fiber.StatusServiceUnavailable,
+			Message: "no active signing key available",
+		})
+	}
 
 	return c.Status(fiber.StatusOK).JSON(defaultRealm)
 }


### PR DESCRIPTION
## Summary

Fixes a `fatal error: concurrent map read and map write` crash originating in the JWKS file provider, plus the local linter tooling that failed to catch it.

### Concurrency fix (`3653ead`, `867ef35`)
- The scheduler goroutine (`executeTask` → `updateCerts`) rewrote `certsCacheMap` **without** holding `cacheMutex`, racing with `GetJwks`/`GetDefaultRealm` reads. `initialize` locked correctly, so the crash only surfaced from the periodic refresh tick.
- `updateCerts` now builds a fresh cache map outside the lock (including file reads and certificate parsing), then acquires `cacheMutex` only to atomically swap `fp.certsCacheMap`.
- `executeTask` no longer holds `cacheMutex` for the full refresh duration, so `GetJwks`/`GetDefaultRealm` continue serving stale cache data during refresh.
- Guard `GetDefaultRealm` against a missing `Active` key — returns `nil` instead of a nil-pointer panic; `IssuerHandler` now responds `503 Service Unavailable`.
- Enable `-race` in `make test-unit` so CI catches this class of bug. The existing `TestGetJwks/validate_that_the_scheduler_is_running` reliably reports `WARNING: DATA RACE` without the fix.

### Linter tooling fix (`ab0c5b3`)
- `.golangci.yml` is a golangci-lint **v2** config (enables `funcorder`), but the Makefile pinned **v1.63.4** → local `make lint` failed with `unknown linters: 'funcorder'`. (CI was unaffected: it uses `golangci-lint-action@v9.2.0` → v2.)
- Bump pinned version to **v2.7.1** and update the module install path to the `/v2` path; refresh the stale config header comment.

## Verification
- `make test-unit` (now with `-race`): all pass — jwks 85.6%, server 95.0% coverage
- `go vet ./...`: clean
- `make lint`: `0 issues.` · `make lint-config`: verifies clean